### PR TITLE
Make com.ibm.jbatch.tck.tests.jslxml.CDITests#testCDILookup(...) portable by using a bean indirection instead of jbatch annotations directly

### DIFF
--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/artifacts/cdi/NonCDIBeanBatchlet.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/artifacts/cdi/NonCDIBeanBatchlet.java
@@ -18,29 +18,13 @@
 */
 package com.ibm.jbatch.tck.artifacts.cdi;
 
-import jakarta.batch.api.BatchProperty;
+import com.ibm.jbatch.tck.cdi.NamedTestBean;
 import jakarta.batch.api.Batchlet;
 import jakarta.batch.runtime.context.JobContext;
 import jakarta.batch.runtime.context.StepContext;
 import jakarta.enterprise.inject.spi.CDI;
-import jakarta.enterprise.util.AnnotationLiteral;
 
 public class NonCDIBeanBatchlet implements Batchlet {
-
-    private class BatchPropertyLiteral extends AnnotationLiteral<BatchProperty> implements BatchProperty {
-
-        private String name;
-
-        BatchPropertyLiteral(String name) {
-            this.name = name;
-        }
-
-        @Override
-        public String name() {
-            return name;
-        }
-    }
-
 
     @Override
     public String process() throws Exception {
@@ -48,11 +32,9 @@ public class NonCDIBeanBatchlet implements Batchlet {
         
         JobContext jobCtx = cdi.select(JobContext.class).get();
         StepContext stepCtx = cdi.select(StepContext.class).get();
-        String prop1Val =  cdi.select(String.class, new BatchPropertyLiteral("prop1")).get();
-        String prop2Val =  cdi.select(String.class, new BatchPropertyLiteral("prop2")).get();
+        NamedTestBean bean =  cdi.select(NamedTestBean.class).get();
 
-
-        appendExitStatus(jobCtx, jobCtx.getExecutionId() + ":" + stepCtx.getStepName() + ":" + prop1Val + ":" + prop2Val);
+        appendExitStatus(jobCtx, jobCtx.getExecutionId() + ":" + stepCtx.getStepName() + ":" + bean.getProp1() + ":" + bean.getProp2());
 
         return "OK";
     }

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/cdi/NamedTestBean.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/cdi/NamedTestBean.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2024 International Business Machines Corp. and others
+ *
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership. Licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.jbatch.tck.cdi;
+
+import jakarta.batch.api.BatchProperty;
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+
+@Dependent
+@Named("NamedTestBean")
+public class NamedTestBean {
+
+    @Inject
+    @BatchProperty(name = "prop1")
+    private String prop1;
+
+    @Inject
+    @BatchProperty
+    private String prop2;
+
+    public String getProp1() {
+        return prop1;
+    }
+
+    public String getProp2() {
+        return prop2;
+    }
+}


### PR DESCRIPTION
# What does this PR do?

We are currently working on updating Geronimo BatchEE to be compliant with Jakarta Batch 2.1 via a [PR](https://github.com/apache/geronimo-batchee/pull/21). 

While working on TCK compliance, we encountered an issue with `com.ibm.jbatch.tck.tests.jslxml.CDITests#testCDILookup(...)`.

This test makes use of dynamic injections via `CDI.current()` of `@BatchProperty` via an `AnnotationLiteral`. 

In case of the reference impl, Weld will create a "dynamic" (mock) injection point, so the `BatchProducerBean` will return the correct properties. OWB doesn't create such a "mock" injection point, so it isn't possible to obtain the qualifier as `InjectionPoint#getMember` cannot be null (see the javadoc and the logger example). Overall, this is most likely a thing to discuss on the CDI side.

Therefore, I would like to propose to adjust the actual test on the batch tck to be portable by adding an indirection on a bean which gets jbatch injections instead of using CDI.current() on the jbatch injections directly. This will still test the same thing but should be (more) portable.


